### PR TITLE
Add Vite React plugin dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "vite": "^4.3.9",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- ensure Vite can build React frontend by adding `@vitejs/plugin-react` to dev dependencies
- add a `.gitignore` to keep node modules and lock files out of version control

## Testing
- `npm test` (frontend)
- `npm run build` (frontend) *(fails: Cannot find package '@vitejs/plugin-react' due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68961f49853c832196266029089a11ae