### PR TITLE
Add Vite React plugin dependency and restore API helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "vite": "^4.3.9",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import io from 'socket.io-client';
 
-
+const api = async (
+  path: string,
+  method = 'GET',
+  body?: any,
+  token?: string,
+) => {
+  const res = await fetch(`/api${path}`, {
     method,
     headers: {
       'Content-Type': 'application/json',
@@ -53,6 +59,7 @@ export default function App() {
     if (!token || !chatId) return;
     const msgs = await api(`/messages/${chatId}`, 'GET', undefined, token);
     setMessages(msgs);
+    const s = io({ auth: { token } });
     s.emit('join', chatId);
     s.on('message', (msg: any) => {
       if (msg.chatId === chatId) {


### PR DESCRIPTION
## Summary
- ensure Vite can build React frontend by adding `@vitejs/plugin-react` to dev dependencies
- add a `.gitignore` to keep node modules and lock files out of version control
- fix frontend build errors by restoring the `api` helper and socket initialization

## Testing
- `npm test` (frontend)
- `npm install` (frontend) *(fails: 403 Forbidden - @vitejs/plugin-react)*
- `npm run build` (frontend) *(fails: Cannot find package '@vitejs/plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_68961f49853c832196266029089a11ae