### PR TITLE
Handle socket.io setup after Fastify is ready

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,9 +36,13 @@ app.register(tagRoutes, { prefix: '/tags' });
 
 app.get('/', async () => ({ status: 'ok' }));
 
-(app as any).io.on('connection', (socket: any) => {
-  socket.on('join', (chatId: string) => {
-    socket.join(`chat:${chatId}`);
+// socket.io plugin is available only after the server is ready
+app.ready(err => {
+  if (err) throw err;
+  (app as any).io.on('connection', (socket: any) => {
+    socket.on('join', (chatId: string) => {
+      socket.join(`chat:${chatId}`);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- initialize socket.io listeners after Fastify is ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689624e960088321909027ee272cf813