### PR TITLE
Fix auth middleware for API-prefixed routes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,8 @@ app.register(authRoutes, { prefix: '/auth' });
 
 // simple auth middleware for subsequent routes
 app.addHook('preHandler', (req, reply, done) => {
-  if (req.url.startsWith('/auth')) return done();
+  const url = req.url.replace(/^\/api/, '');
+  if (url.startsWith('/auth')) return done();
   const auth = req.headers.authorization;
   if (!auth) {
     reply.code(401).send({ error: 'Unauthorized' });


### PR DESCRIPTION
## Summary
- allow `/api/auth/*` routes to bypass authentication check

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896265a393c8321a76c888330c492a3