### PR TITLE
Fix auth middleware for API-prefixed routes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,11 +10,13 @@ import { sessions } from './db';
 const app = Fastify({ logger: true });
 
 app.register(FastifySocketIO);
-app.register(authRoutes, { prefix: '/auth' });
+// expose all API routes under the `/api` prefix to align with frontend requests
+app.register(authRoutes, { prefix: '/api/auth' });
 
 // simple auth middleware for subsequent routes
 app.addHook('preHandler', (req, reply, done) => {
-  if (req.url.startsWith('/auth')) return done();
+  const url = req.url.replace(/^\/api/, '');
+  if (!url || url.startsWith('/auth')) return done();
   const auth = req.headers.authorization;
   if (!auth) {
     reply.code(401).send({ error: 'Unauthorized' });
@@ -30,11 +32,11 @@ app.addHook('preHandler', (req, reply, done) => {
   done();
 });
 
-app.register(botRoutes, { prefix: '/bots' });
-app.register(messageRoutes, { prefix: '/messages' });
-app.register(tagRoutes, { prefix: '/tags' });
+app.register(botRoutes, { prefix: '/api/bots' });
+app.register(messageRoutes, { prefix: '/api/messages' });
+app.register(tagRoutes, { prefix: '/api/tags' });
 
-app.get('/', async () => ({ status: 'ok' }));
+app.get('/api', async () => ({ status: 'ok' }));
 
 // socket.io plugin is available only after the server is ready
 app.ready(err => {


### PR DESCRIPTION
## Summary
- expose backend routes under the `/api` prefix to align with frontend requests
- skip auth checks for `/api` root and `/api/auth/*` paths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896265a393c8321a76c888330c492a3