### PR TITLE
feat: add dark theme and responsive layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bot Inbox</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gray-900 text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,63 +90,158 @@ export default function App() {
     setChatTags(ct.filter(Boolean));
   };
 
-  if (!token) {
+    if (!token) {
+      return (
+        <div className="min-h-full flex items-center justify-center p-4">
+          <div className="w-full max-w-sm space-y-4 bg-gray-800 p-6 rounded shadow">
+            <h1 className="text-3xl font-bold text-center">Login</h1>
+            <input
+              className="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+            />
+            <input
+              className="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <button
+                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={handleLogin}
+              >
+                Login
+              </button>
+              <button
+                className="flex-1 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded"
+                onClick={handleRegister}
+              >
+                Register
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     return (
-      <div className="p-4 max-w-md mx-auto">
-        <h1 className="text-2xl font-bold mb-4">Login</h1>
-        <input className="border p-2 w-full mb-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-        <input className="border p-2 w-full mb-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-        <div className="flex gap-2">
-          <button className="bg-blue-500 text-white px-4 py-2" onClick={handleLogin}>Login</button>
-          <button className="bg-gray-500 text-white px-4 py-2" onClick={handleRegister}>Register</button>
+      <div className="min-h-full p-4 md:p-8 space-y-6">
+        <h1 className="text-3xl font-bold text-center md:text-left">Bot Inbox</h1>
+
+        <div className="space-y-6">
+          <div className="space-y-4 bg-gray-800 p-4 rounded shadow">
+            <h2 className="text-lg font-semibold">Bots</h2>
+            <ul className="text-sm text-gray-300">
+              {bots.map(b => (<li key={b.id}>{b.id}</li>))}
+            </ul>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+              <input
+                className="flex-1 px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Bot token"
+                value={botToken}
+                onChange={e => setBotToken(e.target.value)}
+              />
+              <button
+                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+                onClick={addBot}
+              >
+                Add Bot
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-4 bg-gray-800 p-4 rounded shadow">
+            <h2 className="text-lg font-semibold">Chat</h2>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+              <input
+                className="flex-1 px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Chat ID"
+                value={chatId}
+                onChange={e => setChatId(e.target.value)}
+              />
+              <button
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={joinChat}
+              >
+                Join
+              </button>
+            </div>
+            <div className="border border-gray-700 h-64 overflow-y-auto my-2 p-2 rounded bg-gray-900">
+              {messages.map((m, i) => (
+                <div key={i} className={m.fromClient ? 'text-left' : 'text-right'}>
+                  <span
+                    className={`inline-block px-3 py-1 rounded mb-1 text-white ${m.fromClient ? 'bg-blue-600' : 'bg-gray-700'}`}
+                  >
+                    {m.text}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <input
+                className="flex-1 px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={messageText}
+                onChange={e => setMessageText(e.target.value)}
+              />
+              <button
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={sendMessage}
+              >
+                Send
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-4 bg-gray-800 p-4 rounded shadow">
+            <h2 className="text-lg font-semibold">Tags</h2>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input
+                className="flex-1 px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Name"
+                value={tagName}
+                onChange={e => setTagName(e.target.value)}
+              />
+              <input
+                className="w-20 h-10 rounded bg-gray-700 border border-gray-600"
+                type="color"
+                value={tagColor}
+                onChange={e => setTagColor(e.target.value)}
+              />
+              <button
+                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+                onClick={createTag}
+              >
+                Create
+              </button>
+            </div>
+            <div className="flex gap-2 flex-wrap mb-2">
+              {tags.map(t => (
+                <button
+                  key={t.id}
+                  style={{ background: t.color }}
+                  className="px-2 py-1 rounded text-white"
+                  onClick={() => assignTag(t.id)}
+                >
+                  {t.name}
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2 flex-wrap">
+              {chatTags.map((t: any) => (
+                <span
+                  key={t.id}
+                  style={{ background: t.color }}
+                  className="px-2 py-1 rounded text-white"
+                >
+                  {t.name}
+                </span>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     );
-  }
-
-  return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Bot Inbox</h1>
-      <div className="mb-4">
-        <h2 className="font-semibold">Bots</h2>
-        <ul>{bots.map(b => (<li key={b.id}>{b.id}</li>))}</ul>
-        <input className="border p-2 mr-2" placeholder="Bot token" value={botToken} onChange={e => setBotToken(e.target.value)} />
-        <button className="bg-green-500 text-white px-2 py-1" onClick={addBot}>Add Bot</button>
-      </div>
-
-      <div className="mb-4">
-        <h2 className="font-semibold">Chat</h2>
-        <input className="border p-2 mr-2" placeholder="Chat ID" value={chatId} onChange={e => setChatId(e.target.value)} />
-        <button className="bg-blue-500 text-white px-2 py-1" onClick={joinChat}>Join</button>
-        <div className="border h-64 overflow-y-auto my-2 p-2">
-          {messages.map((m, i) => (
-            <div key={i} className={m.fromClient ? 'text-left' : 'text-right'}>
-              <span className="inline-block bg-gray-200 px-2 py-1 rounded mb-1">{m.text}</span>
-            </div>
-          ))}
-        </div>
-        <input className="border p-2 w-full mb-2" value={messageText} onChange={e => setMessageText(e.target.value)} />
-        <button className="bg-blue-500 text-white px-4 py-2" onClick={sendMessage}>Send</button>
-      </div>
-
-      <div>
-        <h2 className="font-semibold">Tags</h2>
-        <div className="flex gap-2 mb-2">
-          <input className="border p-2" placeholder="Name" value={tagName} onChange={e => setTagName(e.target.value)} />
-          <input className="border p-2" type="color" value={tagColor} onChange={e => setTagColor(e.target.value)} />
-          <button className="bg-green-500 text-white px-2" onClick={createTag}>Create</button>
-        </div>
-        <div className="flex gap-2 flex-wrap mb-2">
-          {tags.map(t => (
-            <button key={t.id} style={{ background: t.color }} className="px-2 py-1" onClick={() => assignTag(t.id)}>{t.name}</button>
-          ))}
-        </div>
-        <div className="flex gap-2 flex-wrap">
-          {chatTags.map((t: any) => (
-            <span key={t.id} style={{ background: t.color }} className="px-2 py-1 rounded text-white">{t.name}</span>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html, body, #root {
+    @apply h-full;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {}


### PR DESCRIPTION
## Summary
- add dark theme and responsive layout across the app
- enable Tailwind dark mode and base styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896292f56888321896ba6290eebbb98