### PR TITLE
Fix register route and dark login style

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ import { sessions } from './db';
 const app = Fastify({ logger: true });
 
 app.register(FastifySocketIO);
-app.register(authRoutes, { prefix: '/auth' });
+app.register(authRoutes, { prefix: '/api/auth' });
 
 // simple auth middleware for subsequent routes
 app.addHook('preHandler', (req, reply, done) => {
@@ -31,11 +31,11 @@ app.addHook('preHandler', (req, reply, done) => {
   done();
 });
 
-app.register(botRoutes, { prefix: '/bots' });
-app.register(messageRoutes, { prefix: '/messages' });
-app.register(tagRoutes, { prefix: '/tags' });
+app.register(botRoutes, { prefix: '/api/bots' });
+app.register(messageRoutes, { prefix: '/api/messages' });
+app.register(tagRoutes, { prefix: '/api/tags' });
 
-app.get('/', async () => ({ status: 'ok' }));
+app.get('/api', async () => ({ status: 'ok' }));
 
 // socket.io plugin is available only after the server is ready
 app.ready(err => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,9 +92,9 @@ export default function App() {
 
     if (!token) {
       return (
-        <div className="min-h-full flex items-center justify-center p-4">
-          <div className="w-full max-w-sm space-y-4 bg-gray-800 p-6 rounded shadow">
-            <h1 className="text-3xl font-bold text-center">Login</h1>
+        <div className="min-h-full flex items-center justify-center">
+          <div className="w-full max-w-sm space-y-6 p-8 bg-gray-800 border border-gray-700 rounded">
+            <h1 className="text-2xl font-semibold text-center">Sign in</h1>
             <input
               className="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Email"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,6 @@
 
 @layer base {
   html, body, #root {
-    @apply h-full;
+    @apply h-full bg-gray-900 text-white;
   }
 }


### PR DESCRIPTION
## Summary
- prefix backend routes with `/api` to prevent 404s during registration
- apply dark minimalist styling to the login screen

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962b5de78c8321a88dedbd40c03f3a